### PR TITLE
Enable syntax highlighting in code fences

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,10 @@ disqusShortname = "sergiandreplace"
 googleAnalytics = "UA-203854-6"
 publishDir = "docs"
 
+# Enable syntax highlighting in code fences
+# see https://gohugo.io/content-management/syntax-highlighting/#highlight-in-code-fences
+pygmentsCodeFences=true
+
 [permalinks]
   post = "/:year/:month/:slug/"
 


### PR DESCRIPTION
Simple option to enable highlighting 
issue #1 
See https://gohugo.io/content-management/syntax-highlighting/#highlight-in-code-fences
if this does not work maybe there is some python stuff missing, there shows how to deal with it